### PR TITLE
1.14.4 fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>xyz.upperlevel.spigot.book</groupId>
     <artifactId>spigot-book-api</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
 
     <name>BookApi</name>
     <description>A low-level API for book control on spigot</description>

--- a/src/main/java/xyz/upperlevel/spigot/book/NmsBookHelper.java
+++ b/src/main/java/xyz/upperlevel/spigot/book/NmsBookHelper.java
@@ -53,18 +53,12 @@ public final class NmsBookHelper {
 
     static {
         version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-        final int major, minor, minorMinor;
+        final int major, minor;
         Pattern pattern = Pattern.compile("v([0-9]+)_([0-9]+)");
         Matcher m = pattern.matcher(version);
         if (m.find()) {
             major = Integer.parseInt(m.group(1));
             minor = Integer.parseInt(m.group(2));
-
-            if (m.groupCount() > 2) {
-                minorMinor = Integer.parseInt(m.group(3));
-            } else {
-                minorMinor = -1;
-            }
         } else {
             throw new IllegalStateException(
                     "Cannot parse version \"" + version + "\", make sure it follows \"v<major>_<minor>...\"");
@@ -88,11 +82,15 @@ public final class NmsBookHelper {
             if (doubleHands) {
                 final Class<?> enumHandClass = getNmsClass("EnumHand");
 
-                if (!is_1_14_4_OrNewer(major, minor, minorMinor)) {
-                    entityPlayerOpenBook = entityPlayerClass.getMethod("a", itemStackClass, enumHandClass);
-                } else {
-                    entityPlayerOpenBook = entityPlayerClass.getMethod("openBook", itemStackClass, enumHandClass);
+                Method openBookMethod;
+
+                try {
+                    openBookMethod = entityPlayerClass.getMethod("a", itemStackClass, enumHandClass);
+                } catch (NoSuchMethodException e) {
+                    openBookMethod = entityPlayerClass.getMethod("openBook", itemStackClass, enumHandClass);
                 }
+
+                entityPlayerOpenBook = openBookMethod;
 
                 hands = enumHandClass.getEnumConstants();
             } else {
@@ -123,18 +121,6 @@ public final class NmsBookHelper {
         } catch (Exception e) {
             throw new IllegalStateException("Cannot initiate reflections for " + version, e);
         }
-    }
-
-    private static boolean is_1_14_4_OrNewer(int major, int minor, int minorMinor) {
-        if (major <= 1) {
-            if (minor == 14) {
-                return minorMinor >= 4;
-            }
-
-            return minor > 14;
-        }
-
-        return true;
     }
 
     /**

--- a/src/main/java/xyz/upperlevel/spigot/book/NmsBookHelper.java
+++ b/src/main/java/xyz/upperlevel/spigot/book/NmsBookHelper.java
@@ -30,19 +30,21 @@ public final class NmsBookHelper {
     private static final Method chatSerializerA;
 
     private static final Method craftPlayerGetHandle;
-    //This method takes an enum that represents the player's hand only in versions >= 1.9
-    //In the other versions it only takes the nms item
+    // This method takes an enum that represents the player's hand only in versions
+    // >= 1.9
+    // In the other versions it only takes the nms item
     private static final Method entityPlayerOpenBook;
-    //only version >= 1.9
+    // only version >= 1.9
     private static final Object[] hands;
 
-
-    //Older versions
-    /*private static final Field entityHumanPlayerConnection;
-    private static final Method playerConnectionSendPacket;
-
-    private static final Constructor<?> packetPlayOutCustomPayloadConstructor;
-    private static final Constructor<?> packetDataSerializerConstructor;*/
+    // Older versions
+    /*
+     * private static final Field entityHumanPlayerConnection; private static final
+     * Method playerConnectionSendPacket;
+     * 
+     * private static final Constructor<?> packetPlayOutCustomPayloadConstructor;
+     * private static final Constructor<?> packetDataSerializerConstructor;
+     */
 
     private static final Method nmsItemStackSave;
     private static final Constructor<?> nbtTagCompoundConstructor;
@@ -51,14 +53,21 @@ public final class NmsBookHelper {
 
     static {
         version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-        final int major, minor;
+        final int major, minor, minorMinor;
         Pattern pattern = Pattern.compile("v([0-9]+)_([0-9]+)");
         Matcher m = pattern.matcher(version);
-        if(m.find()) {
+        if (m.find()) {
             major = Integer.parseInt(m.group(1));
             minor = Integer.parseInt(m.group(2));
+
+            if (m.groupCount() > 2) {
+                minorMinor = Integer.parseInt(m.group(3));
+            } else {
+                minorMinor = -1;
+            }
         } else {
-            throw new IllegalStateException("Cannot parse version \"" + version + "\", make sure it follows \"v<major>_<minor>...\"");
+            throw new IllegalStateException(
+                    "Cannot parse version \"" + version + "\", make sure it follows \"v<major>_<minor>...\"");
         }
         doubleHands = major <= 1 && minor >= 9;
         try {
@@ -66,7 +75,7 @@ public final class NmsBookHelper {
             craftMetaBookField = craftMetaBookClass.getDeclaredField("pages");
             craftMetaBookField.setAccessible(true);
             Class<?> chatSerializer = getNmsClass("IChatBaseComponent$ChatSerializer", false);
-            if(chatSerializer == null)
+            if (chatSerializer == null)
                 chatSerializer = getNmsClass("ChatSerializer");
 
             chatSerializerA = chatSerializer.getDeclaredMethod("a", String.class);
@@ -76,22 +85,33 @@ public final class NmsBookHelper {
 
             final Class<?> entityPlayerClass = getNmsClass("EntityPlayer");
             final Class<?> itemStackClass = getNmsClass("ItemStack");
-            if(doubleHands) {
+            if (doubleHands) {
                 final Class<?> enumHandClass = getNmsClass("EnumHand");
-                entityPlayerOpenBook = entityPlayerClass.getMethod("a", itemStackClass, enumHandClass);
+
+                if (!is_1_14_4_OrNewer(major, minor, minorMinor)) {
+                    entityPlayerOpenBook = entityPlayerClass.getMethod("a", itemStackClass, enumHandClass);
+                } else {
+                    entityPlayerOpenBook = entityPlayerClass.getMethod("openBook", itemStackClass, enumHandClass);
+                }
+
                 hands = enumHandClass.getEnumConstants();
             } else {
                 entityPlayerOpenBook = entityPlayerClass.getMethod("openBook", itemStackClass);
                 hands = null;
             }
-            //Older versions
-            /*entityHumanPlayerConnection = entityPlayerClass.getField("playerConnection");
-            final Class<?> playerConnectionClass = getNmsClass("PlayerConnection");
-            playerConnectionSendPacket = playerConnectionClass.getMethod("sendPacket", getNmsClass("Packet"));
-
-            final Class<?> packetDataSerializerClasss = getNmsClass("PacketDataSerializer");
-            packetPlayOutCustomPayloadConstructor = getNmsClass("PacketPlayOutCustomPayload").getConstructor(String.class, packetDataSerializerClasss);
-            packetDataSerializerConstructor = packetDataSerializerClasss.getConstructor(ByteBuf.class);*/
+            // Older versions
+            /*
+             * entityHumanPlayerConnection = entityPlayerClass.getField("playerConnection");
+             * final Class<?> playerConnectionClass = getNmsClass("PlayerConnection");
+             * playerConnectionSendPacket = playerConnectionClass.getMethod("sendPacket",
+             * getNmsClass("Packet"));
+             * 
+             * final Class<?> packetDataSerializerClasss =
+             * getNmsClass("PacketDataSerializer"); packetPlayOutCustomPayloadConstructor =
+             * getNmsClass("PacketPlayOutCustomPayload").getConstructor(String.class,
+             * packetDataSerializerClasss); packetDataSerializerConstructor =
+             * packetDataSerializerClasss.getConstructor(ByteBuf.class);
+             */
 
             final Class<?> craftItemStackClass = getCraftClass("inventory.CraftItemStack");
             craftItemStackAsNMSCopy = craftItemStackClass.getMethod("asNMSCopy", ItemStack.class);
@@ -105,20 +125,32 @@ public final class NmsBookHelper {
         }
     }
 
+    private static boolean is_1_14_4_OrNewer(int major, int minor, int minorMinor) {
+        if (major <= 1) {
+            if (minor == 14) {
+                return minorMinor >= 4;
+            }
+
+            return minor > 14;
+        }
+
+        return true;
+    }
 
     /**
      * Sets the pages of the book to the components json equivalent
-     * @param meta the book meta to change
+     * 
+     * @param meta       the book meta to change
      * @param components the pages of the book
      */
-    @SuppressWarnings("unchecked")//reflections = unchecked warnings
+    @SuppressWarnings("unchecked") // reflections = unchecked warnings
     public static void setPages(BookMeta meta, BaseComponent[][] components) {
         try {
             List<Object> pages = (List<Object>) craftMetaBookField.get(meta);
             pages.clear();
-            for(BaseComponent[] c : components) {
+            for (BaseComponent[] c : components) {
                 final String json = ComponentSerializer.toString(c);
-                //System.out.println("page:" + json); //Debug
+                // System.out.println("page:" + json); //Debug
                 pages.add(chatSerializerA.invoke(null, json));
             }
         } catch (Exception e) {
@@ -127,82 +159,75 @@ public final class NmsBookHelper {
     }
 
     /**
-     * Opens the book to a player (the player needs to have the book in one of his hands)
-     * @param player the player
-     * @param book the book to open
+     * Opens the book to a player (the player needs to have the book in one of his
+     * hands)
+     * 
+     * @param player  the player
+     * @param book    the book to open
      * @param offHand false if the book is in the right hand, true otherwise
      */
     public static void openBook(Player player, ItemStack book, boolean offHand) {
-        //nms(player).openBook(nms(player), nms(book), hand);
+        // nms(player).openBook(nms(player), nms(book), hand);
         try {
-            //Older versions:
-            /*playerConnectionSendPacket.invoke(
-                    entityHumanPlayerConnection.get(toNms(player)),
-                    createBookOpenPacket()
-            );*/
-            if(doubleHands) {
-                entityPlayerOpenBook.invoke(
-                        toNms(player),
-                        nmsCopy(book),
-                        hands[offHand ? 1 : 0]
-                );
+            // Older versions:
+            /*
+             * playerConnectionSendPacket.invoke(
+             * entityHumanPlayerConnection.get(toNms(player)), createBookOpenPacket() );
+             */
+            if (doubleHands) {
+                entityPlayerOpenBook.invoke(toNms(player), nmsCopy(book), hands[offHand ? 1 : 0]);
             } else {
-                entityPlayerOpenBook.invoke(
-                        toNms(player),
-                        nmsCopy(book)
-                );
+                entityPlayerOpenBook.invoke(toNms(player), nmsCopy(book));
             }
         } catch (Exception e) {
             throw new UnsupportedVersionException(e);
         }
     }
 
-    //Older versions
-    /*public static Object createBookOpenPacket() {
-        //new PacketPlayOutCustomPayload("MC|BOpen", new PacketDataSerializer(Unpooled.buffer())));
-        try {
-            return packetPlayOutCustomPayloadConstructor.newInstance(
-                    "MC|BOpen",
-                    packetDataSerializerConstructor.newInstance(Unpooled.buffer())
-            );
-        } catch (Exception e) {
-            throw new UnsupportedVersionException(e);
-        }
-    }*/
+    // Older versions
+    /*
+     * public static Object createBookOpenPacket() { //new
+     * PacketPlayOutCustomPayload("MC|BOpen", new
+     * PacketDataSerializer(Unpooled.buffer()))); try { return
+     * packetPlayOutCustomPayloadConstructor.newInstance( "MC|BOpen",
+     * packetDataSerializerConstructor.newInstance(Unpooled.buffer()) ); } catch
+     * (Exception e) { throw new UnsupportedVersionException(e); } }
+     */
 
     /**
      * Translates an ItemStack to his Chat-Component equivalent
+     * 
      * @param item the item to be converted
      * @return a Chat-Component equivalent of the parameter
      */
     public static BaseComponent[] itemToComponents(ItemStack item) {
-       return jsonToComponents(itemToJson(item));
+        return jsonToComponents(itemToJson(item));
     }
 
     /**
      * Translates a json string to his Chat-Component equivalent
+     * 
      * @param json the json string to be converted
      * @return a Chat-Component equivalent of the parameter
      */
     public static BaseComponent[] jsonToComponents(String json) {
-        return new BaseComponent[] {
-                new TextComponent(json)
-        };
+        return new BaseComponent[] { new TextComponent(json) };
     }
 
     /**
      * Translates an ItemStack to his json equivalent
+     * 
      * @param item the item to be converted
      * @return a json equivalent of the parameter
      */
     private static String itemToJson(ItemStack item) {
         try {
-            //net.minecraft.server.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
+            // net.minecraft.server.ItemStack nmsItemStack =
+            // CraftItemStack.asNMSCopy(itemStack);
             Object nmsItemStack = nmsCopy(item);
 
-
-            //net.minecraft.server.NBTTagCompound compound = new NBTTagCompound();
-            //compound = nmsItemStack.save(compound);
+            // net.minecraft.server.NBTTagCompound compound = new NBTTagCompound();
+            // compound = nmsItemStack.save(compound);
             Object emptyTag = nbtTagCompoundConstructor.newInstance();
             Object json = nmsItemStackSave.invoke(nmsItemStack, emptyTag);
             return json.toString();
@@ -212,7 +237,8 @@ public final class NmsBookHelper {
     }
 
     /**
-     * An error thrown when this NMS-helper class doesn't support the running MC version
+     * An error thrown when this NMS-helper class doesn't support the running MC
+     * version
      */
     public static class UnsupportedVersionException extends RuntimeException {
         /**
@@ -222,17 +248,20 @@ public final class NmsBookHelper {
         private final String version = NmsBookHelper.version;
 
         public UnsupportedVersionException(Exception e) {
-            super("Error while executing reflections, submit to developers the following log (version: " + NmsBookHelper.version + ")", e);
+            super("Error while executing reflections, submit to developers the following log (version: "
+                    + NmsBookHelper.version + ")", e);
         }
     }
 
-
     /**
      * Gets the EntityPlayer handled by the argument
+     * 
      * @param player the Player handler
      * @return the handled class
-     * @throws InvocationTargetException when some problems are found with the reflection
-     * @throws IllegalAccessException when some problems are found with the reflection
+     * @throws InvocationTargetException when some problems are found with the
+     *                                   reflection
+     * @throws IllegalAccessException    when some problems are found with the
+     *                                   reflection
      */
     public static Object toNms(Player player) throws InvocationTargetException, IllegalAccessException {
         return craftPlayerGetHandle.invoke(player);
@@ -240,10 +269,13 @@ public final class NmsBookHelper {
 
     /**
      * Creates a NMS copy of the parameter
+     * 
      * @param item the ItemStack to be nms-copied
      * @return a NMS-ItemStack that is the equivalent of the one passed as argument
-     * @throws InvocationTargetException when some problems are found with the reflection
-     * @throws IllegalAccessException when some problems are found with the reflection
+     * @throws InvocationTargetException when some problems are found with the
+     *                                   reflection
+     * @throws IllegalAccessException    when some problems are found with the
+     *                                   reflection
      */
     public static Object nmsCopy(ItemStack item) throws InvocationTargetException, IllegalAccessException {
         return craftItemStackAsNMSCopy.invoke(null, item);
@@ -252,8 +284,8 @@ public final class NmsBookHelper {
     public static Class<?> getNmsClass(String className, boolean log) {
         try {
             return Class.forName("net.minecraft.server." + version + "." + className);
-        } catch(ClassNotFoundException e) {
-            if(log)
+        } catch (ClassNotFoundException e) {
+            if (log)
                 e.printStackTrace();
             return null;
         }
@@ -263,11 +295,10 @@ public final class NmsBookHelper {
         return getNmsClass(className, true);
     }
 
-
     private static Class<?> getCraftClass(String path) {
         try {
             return Class.forName("org.bukkit.craftbukkit." + version + "." + path);
-        } catch(ClassNotFoundException e) {
+        } catch (ClassNotFoundException e) {
             e.printStackTrace();
             return null;
         }


### PR DESCRIPTION
Fix for Minecraft 1.14.4. The Method "EntityPlayer#a(ItemStack, EnumHand)" has been given the proper Name "EntityPlayer#openBook(ItemStack, EnumHand)" in 1.14.4.

Looks like VSCode's formatter was also let loose on the File..