### PR TITLE
Fix issue #9 (Internal representation change in 1.16.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To include the API in your project put this into our pom.xml (maven)
   <dependency>
     <groupId>xyz.upperlevel.spigot.book</groupId>
     <artifactId>spigot-book-api</artifactId>
-    <version>1.3</version>
+    <version>1.4</version>
   </dependency>
 </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <url>https://github.com/upperlevel/spigot-book-api</url>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <mc-version>1.12-pre6-SNAPSHOT</mc-version>
@@ -44,7 +45,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.16</version>
+            <version>1.18.16</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -85,7 +86,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.3</version>
                 <configuration>
                     <descriptor>src/assembly/dep.xml</descriptor>
                 </configuration>
@@ -99,7 +99,6 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -127,7 +126,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -140,7 +139,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>xyz.upperlevel.spigot.book</groupId>
     <artifactId>spigot-book-api</artifactId>
-    <version>1.3</version>
+    <version>1.4</version>
 
     <name>BookApi</name>
     <description>A low-level API for book control on spigot</description>

--- a/src/main/java/xyz/upperlevel/spigot/book/BookUtil.java
+++ b/src/main/java/xyz/upperlevel/spigot/book/BookUtil.java
@@ -64,7 +64,8 @@ public final class BookUtil {
 
     /**
      * Creates a BookBuilder instance with a written book as the Itemstack's type
-     * @return
+     *
+     * @return A book builder with the material of {@link Material#WRITTEN_BOOK}
      */
     public static BookBuilder writtenBook() {
         return new BookBuilder(new ItemStack(Material.WRITTEN_BOOK));

--- a/src/main/java/xyz/upperlevel/spigot/book/NmsBookHelper.java
+++ b/src/main/java/xyz/upperlevel/spigot/book/NmsBookHelper.java
@@ -5,7 +5,6 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
 import org.bukkit.Bukkit;
-import org.bukkit.block.banner.PatternType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
@@ -22,12 +21,16 @@ import java.util.regex.Pattern;
  * The NMS helper for all the Book-API
  */
 public final class NmsBookHelper {
+
     private static final String version;
     private static final boolean doubleHands;
 
     private static final Class<?> craftMetaBookClass;
     private static final Field craftMetaBookField;
     private static final Method chatSerializerA;
+
+    //nullable
+    private static final Method craftMetaBookInternalAddPageMethod;
 
     private static final Method craftPlayerGetHandle;
     // This method takes an enum that represents the player's hand only in versions
@@ -41,7 +44,7 @@ public final class NmsBookHelper {
     /*
      * private static final Field entityHumanPlayerConnection; private static final
      * Method playerConnectionSendPacket;
-     * 
+     *
      * private static final Constructor<?> packetPlayOutCustomPayloadConstructor;
      * private static final Constructor<?> packetDataSerializerConstructor;
      */
@@ -66,8 +69,22 @@ public final class NmsBookHelper {
         doubleHands = major <= 1 && minor >= 9;
         try {
             craftMetaBookClass = getCraftClass("inventory.CraftMetaBook");
+
             craftMetaBookField = craftMetaBookClass.getDeclaredField("pages");
             craftMetaBookField.setAccessible(true);
+
+            Method cmbInternalAddMethod = null;
+            try {
+                //method is protected
+                cmbInternalAddMethod = craftMetaBookClass.getDeclaredMethod("internalAddPage", String.class);
+                cmbInternalAddMethod.setAccessible(true);
+            } catch (NoSuchMethodException e) {
+                //Internal data change in 1.16.4
+                //To detect if the server is using the new internal format we check if the internalAddPageMethod exists
+                //see https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/560b65c4f8a15619aaa4a1737c7040f21e725cce
+            }
+            craftMetaBookInternalAddPageMethod = cmbInternalAddMethod;
+
             Class<?> chatSerializer = getNmsClass("IChatBaseComponent$ChatSerializer", false);
             if (chatSerializer == null) {
                 chatSerializer = getNmsClass("ChatSerializer");
@@ -106,7 +123,7 @@ public final class NmsBookHelper {
              * final Class<?> playerConnectionClass = getNmsClass("PlayerConnection");
              * playerConnectionSendPacket = playerConnectionClass.getMethod("sendPacket",
              * getNmsClass("Packet"));
-             * 
+             *
              * final Class<?> packetDataSerializerClasss =
              * getNmsClass("PacketDataSerializer"); packetPlayOutCustomPayloadConstructor =
              * getNmsClass("PacketPlayOutCustomPayload").getConstructor(String.class,
@@ -128,7 +145,7 @@ public final class NmsBookHelper {
 
     /**
      * Sets the pages of the book to the components json equivalent
-     * 
+     *
      * @param meta       the book meta to change
      * @param components the pages of the book
      */
@@ -136,10 +153,22 @@ public final class NmsBookHelper {
     public static void setPages(BookMeta meta, BaseComponent[][] components) {
         try {
             List<Object> pages = (List<Object>) craftMetaBookField.get(meta);
-            pages.clear();
+            if (pages != null) {
+                pages.clear();
+            }
             for (BaseComponent[] c : components) {
-                final String json = ComponentSerializer.toString(c);
-                pages.add(chatSerializerA.invoke(null, json));
+                if (craftMetaBookInternalAddPageMethod != null) {
+                    if (c == null) {
+                        continue;
+                    }
+                    final String json = ComponentSerializer.toString(c);
+                    craftMetaBookInternalAddPageMethod.invoke(meta, json);
+                }
+                else {
+                    final String json = ComponentSerializer.toString(c);
+                    //noinspection ConstantConditions
+                    pages.add(chatSerializerA.invoke(null, json));
+                }
             }
         } catch (Exception e) {
             throw new UnsupportedVersionException(e);
@@ -149,7 +178,7 @@ public final class NmsBookHelper {
     /**
      * Opens the book to a player (the player needs to have the book in one of his
      * hands)
-     * 
+     *
      * @param player  the player
      * @param book    the book to open
      * @param offHand false if the book is in the right hand, true otherwise
@@ -184,7 +213,7 @@ public final class NmsBookHelper {
 
     /**
      * Translates an ItemStack to his Chat-Component equivalent
-     * 
+     *
      * @param item the item to be converted
      * @return a Chat-Component equivalent of the parameter
      */
@@ -194,7 +223,7 @@ public final class NmsBookHelper {
 
     /**
      * Translates a json string to his Chat-Component equivalent
-     * 
+     *
      * @param json the json string to be converted
      * @return a Chat-Component equivalent of the parameter
      */
@@ -204,7 +233,7 @@ public final class NmsBookHelper {
 
     /**
      * Translates an ItemStack to his json equivalent
-     * 
+     *
      * @param item the item to be converted
      * @return a json equivalent of the parameter
      */
@@ -243,7 +272,7 @@ public final class NmsBookHelper {
 
     /**
      * Gets the EntityPlayer handled by the argument
-     * 
+     *
      * @param player the Player handler
      * @return the handled class
      * @throws InvocationTargetException when some problems are found with the
@@ -257,7 +286,7 @@ public final class NmsBookHelper {
 
     /**
      * Creates a NMS copy of the parameter
-     * 
+     *
      * @param item the ItemStack to be nms-copied
      * @return a NMS-ItemStack that is the equivalent of the one passed as argument
      * @throws InvocationTargetException when some problems are found with the

--- a/src/main/java/xyz/upperlevel/spigot/book/NmsBookHelper.java
+++ b/src/main/java/xyz/upperlevel/spigot/book/NmsBookHelper.java
@@ -157,16 +157,14 @@ public final class NmsBookHelper {
                 pages.clear();
             }
             for (BaseComponent[] c : components) {
+                final String json;
                 if (craftMetaBookInternalAddPageMethod != null) {
-                    if (c == null) {
-                        continue;
-                    }
-                    final String json = ComponentSerializer.toString(c);
+                    json = c != null ? ComponentSerializer.toString(c) : "";
                     craftMetaBookInternalAddPageMethod.invoke(meta, json);
                 }
                 else {
-                    final String json = ComponentSerializer.toString(c);
-                    //noinspection ConstantConditions
+                    BaseComponent[] nonNullC = c != null ? c : jsonToComponents("");
+                    json = ComponentSerializer.toString(nonNullC);
                     pages.add(chatSerializerA.invoke(null, json));
                 }
             }


### PR DESCRIPTION
Due to internal change (caused by bug squashing) the `pages` field in `CraftMetaBook` is now nullable. Generally how pages are added internally was changed to use the protected function `internalAddPage` (see line 294 in [CraftMetaBook](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/560b65c4f8a15619aaa4a1737c7040f21e725cce#src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java)). This will be used instead of a normal add to the underlying list.

The update will also validate the length of the json input. However if this is done when setting the pages it might result in invalid json, and consequently plain text. Thus this patch does not validate the length of the input.

See [CraftBukkit commit](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/560b65c4f8a15619aaa4a1737c7040f21e725cce)

This has been tested on paper [1.16.4-355](https://papermc.io/api/v2/projects/paper/versions/1.16.4/builds/355/downloads/paper-1.16.4-355.jar) and [paper-1.16.4-396](https://papermc.io/api/v2/projects/paper/versions/1.16.4/builds/396/downloads/paper-1.16.4-396.jar). The first is before the mentioned CraftBukkit commit while the second is the latest version as of writing (and of course after the internal changes).
