### PR TITLE
Fix opening books on mc 1.17 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To include the API in your project put this into our pom.xml (maven)
   <dependency>
     <groupId>xyz.upperlevel.spigot.book</groupId>
     <artifactId>spigot-book-api</artifactId>
-    <version>1.4.3</version>
+    <version>1.5</version>
   </dependency>
 </dependencies>
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To include the API in your project put this into our pom.xml (maven)
   <dependency>
     <groupId>xyz.upperlevel.spigot.book</groupId>
     <artifactId>spigot-book-api</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
   </dependency>
 </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>xyz.upperlevel.spigot.book</groupId>
     <artifactId>spigot-book-api</artifactId>
-    <version>1.4.3</version>
+    <version>1.5</version>
 
     <name>BookApi</name>
     <description>A low-level API for book control on spigot</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>xyz.upperlevel.spigot.book</groupId>
     <artifactId>spigot-book-api</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
 
     <name>BookApi</name>
     <description>A low-level API for book control on spigot</description>

--- a/src/main/java/xyz/upperlevel/spigot/book/NmsBookHelper.java
+++ b/src/main/java/xyz/upperlevel/spigot/book/NmsBookHelper.java
@@ -288,7 +288,7 @@ public final class NmsBookHelper {
         return getNms17PlusClass(post17middlePackage + "." + className, required);
     }
 
-    public static Class<?> getNms17PlusClass(String className, boolean required) {
+    private static Class<?> getNms17PlusClass(String className, boolean required) {
         try {
             return Class.forName("net.minecraft." + className);
         } catch (ClassNotFoundException e) {


### PR DESCRIPTION
Closes #24 

Due to changes from [spigots](https://www.spigotmc.org/threads/spigot-bungeecord-1-17.510208/), the long standing tradition of not using subpackages in `net.minecraft.server.<revision>` is gone. This means we must map the NMS classes used to their new subpackage. E.g. pre 1.17 `EntityPlayer` would be `net.minecraft.server.v1_16_R3.EntityPlayer`, while post 1.17 it is `net.minecraft.server.level.EntityPlayer`. 

The solution is simply to map all NMS classes to the new structure to allow this to work again. To do this I've extended the [NmsBookHelper#getNmsClass(String, String, boolean)](https://github.com/elgbar/book-api/blob/00476ca75f02483c6eac4fc9b4f9e114eb3c3d9a/src/main/java/xyz/upperlevel/spigot/book/NmsBookHelper.java#L272-L289) method with an aditional parameter which does the package mapping.

Included in this PR is also additional javadocs, more clearly show what classes cannot be found, and deprecating `NmsBookHelper#getNmsClass(String)`
